### PR TITLE
Handle command-line parsing errors gracefully

### DIFF
--- a/mowedline-client.scm
+++ b/mowedline-client.scm
@@ -54,4 +54,8 @@
   doc: "enable or disable logging; [+-]SYM1,[+-]SYM2,..."
   (dbus:call dbus-context "log" symlist)))
 
-(icla:parse (command-line-arguments))
+(condition-case
+    (icla:parse (command-line-arguments))
+  [ex ()
+      (printf "Error: ~A~%" (get-condition-property ex 'exn 'message))
+      (icla:parse '("-help"))])


### PR DESCRIPTION
Instead of letting command-line parsing errors print a call history have
it print the error and the output for the `-help' command.

This is the only way I could find that we can catch and handle command-line parsing errors. Though there might be some problems with doing it this way.
- From what I've read, parsing doesn't just parse, it also executes the commands it finds. So we don't only catch all exceptions signalled during parsing, but also the ones signalled during execution.
- Since we catch _all_ exceptions, any exception that we'd like to see will be caught and presented without context to the user, along with the help message. I don't think I can catch anything else since the relevant code in imperative-command-line-a uses `error` to signal a generic error message and when I tried to figure out what to catch, chicken tells me it's just an `(exn)`, which is the most generic exception that can be caught for so far as I understand.
- I could find no `call-command` or `icla:call` or anything like it, so I am forced to parse a fictional command-line with only the `-help` command in it to present the user with the help message.

Most of the issues should be fixed in imperative-command-line-a and I'd like to help with that, but I don't know how you'd like to fix it. I'll create some issues and pull-requests to discuss these if you're ok with that. For now this fixes #9 for me.

Please let me know what you think.
