### PR TITLE
Add -config command

### DIFF
--- a/mowedline.scm
+++ b/mowedline.scm
@@ -69,6 +69,7 @@
 
 (define *internal-events* (make-mailbox))
 
+(define user-config-file (make-parameter ""))
 
 ;;;
 ;;; Window Property Utils
@@ -800,7 +801,8 @@
     (and-let* ((_ (not (bypass-startup-script)))
                (path
                 (find file-read-access?
-                      (L (filepath:join-path (L "~" ".mowedline"))
+                      (L (user-config-file)
+                         (filepath:join-path (L "~" ".mowedline"))
                          (filepath:join-path (L "~" ".config" "mowedline" "init.scm"))))))
       (eval '(import mowedline))
       (load path))
@@ -902,6 +904,9 @@
  ((position value)
   doc: "set the default window position (top or bottom)"
   (window-position (string->symbol value)))
+ ((config path)
+  doc: "use a different configuration file"
+  (user-config-file path))
  ((window)
   doc: "make a window containing the foregoing widgets"
   (set! *command-line-windows*


### PR DESCRIPTION
With this command a user can specify a different configuration file than
the two looked for normally. This is useful for testing configuration
changes or when developing mowedline and you don't want to break your
existing configuration.
