### PR TITLE
Don’t draw widgets with no width

### DIFF
--- a/mowedline.scm
+++ b/mowedline.scm
@@ -280,8 +280,9 @@
                   (y 0)
                   (width (xrectangle-width wrect))
                   (height (slot-value window 'height)))
-             (when (member (xrectinregion r x y width height)
-                           (L RECTANGLEPART RECTANGLEIN))
+             (when (and (> width 0)
+                        (member (xrectinregion r x y width height)
+                                (L RECTANGLEPART RECTANGLEIN)))
                ;;intersect r with wrect and pass result to widget-draw
                (let ((wreg (xcreateregion))
                      (out (xcreateregion)))


### PR DESCRIPTION
Widgets with width 0 don’t intersect with anything and shouldn’t be
exposed when the widgets next to them are. Width 0 is interpreted by
‘XClearArea’ to mean the remaining width of the window to the right,
causing other widgets to be cleared erroneously.

Resolves #17.

---

We did it! We fixed it :)
