### PR TITLE
Add proper dbus names to the service

### DIFF
--- a/mowedline-client.scm
+++ b/mowedline-client.scm
@@ -24,10 +24,11 @@
      (prefix imperative-command-line-a icla:))
 
 (include "version")
+(include "mowedline-dbus")
 
-(define dbus-context
-  (dbus:make-context service: 'mowedline.server
-                     interface: 'mowedline.interface))
+(import mowedline-dbus)
+
+(define dbus-context (mowedline-dbus-context))
 
 (icla:help-heading
  (sprintf "mowedline-client version ~A, by John J. Foerch" version))

--- a/mowedline-client.scm
+++ b/mowedline-client.scm
@@ -24,9 +24,7 @@
      (prefix imperative-command-line-a icla:))
 
 (include "version")
-(include "mowedline-dbus")
-
-(define dbus-context (mowedline-dbus-context))
+(include "mowedline-dbus-context")
 
 (icla:help-heading
  (sprintf "mowedline-client version ~A, by John J. Foerch" version))
@@ -34,25 +32,25 @@
 (icla:define-command-group client-options
  ((quit)
   doc: "quit the program"
-  (dbus:call dbus-context "quit"))
+  (dbus:call mowedline-dbus-context "quit"))
 
  ((read widget)
   doc: "updates widget by reading lines from stdin"
   (let loop ()
     (let ((line (read-line (current-input-port))))
       (unless (eof-object? line)
-        (when (equal? '(#f) (dbus:call dbus-context "update" widget line))
+        (when (equal? '(#f) (dbus:call mowedline-dbus-context "update" widget line))
           (printf "widget not found, ~S~%" widget))
         (loop)))))
 
  ((update widget value)
   doc: "updates widget with value"
-  (when (equal? '(#f) (dbus:call dbus-context "update" widget value))
+  (when (equal? '(#f) (dbus:call mowedline-dbus-context "update" widget value))
     (printf "widget not found, ~S~%" widget)))
 
  ((log symlist)
   doc: "enable or disable logging; [+-]SYM1,[+-]SYM2,..."
-  (dbus:call dbus-context "log" symlist)))
+  (dbus:call mowedline-dbus-context "log" symlist)))
 
 (condition-case
     (icla:parse (command-line-arguments))

--- a/mowedline-client.scm
+++ b/mowedline-client.scm
@@ -26,8 +26,6 @@
 (include "version")
 (include "mowedline-dbus")
 
-(import mowedline-dbus)
-
 (define dbus-context (mowedline-dbus-context))
 
 (icla:help-heading

--- a/mowedline-dbus-context.scm
+++ b/mowedline-dbus-context.scm
@@ -20,7 +20,7 @@
 (define mowedline-dbus-service 'net.retroj.mowedline)
 (define mowedline-dbus-interface 'net.retroj.mowedline)
 
-(define (mowedline-dbus-context)
+(define mowedline-dbus-context
   (dbus:make-context service: mowedline-dbus-service
                      interface: mowedline-dbus-interface
                      path: mowedline-dbus-path))

--- a/mowedline-dbus.scm
+++ b/mowedline-dbus.scm
@@ -1,0 +1,31 @@
+;; This file is part of mowedline.
+;; Copyright (C) 2011-2015  John J. Foerch
+;;
+;; mowedline is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; mowedline is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with mowedline.  If not, see <http://www.gnu.org/licenses/>.
+
+(module mowedline-dbus
+    *
+
+(import chicken scheme)
+
+(use (prefix dbus dbus:))
+
+(define mowedline-dbus-path "/net/retroj/mowedline")
+(define mowedline-dbus-service 'net.retroj.mowedline)
+(define mowedline-dbus-interface 'net.retroj.mowedline)
+
+(define (mowedline-dbus-context)
+  (dbus:make-context service: mowedline-dbus-service
+                     interface: mowedline-dbus-interface
+                     path: mowedline-dbus-path)))

--- a/mowedline-dbus.scm
+++ b/mowedline-dbus.scm
@@ -14,11 +14,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with mowedline.  If not, see <http://www.gnu.org/licenses/>.
 
-(module mowedline-dbus
-    *
-
-(import chicken scheme)
-
 (use (prefix dbus dbus:))
 
 (define mowedline-dbus-path "/net/retroj/mowedline")
@@ -28,4 +23,4 @@
 (define (mowedline-dbus-context)
   (dbus:make-context service: mowedline-dbus-service
                      interface: mowedline-dbus-interface
-                     path: mowedline-dbus-path)))
+                     path: mowedline-dbus-path))

--- a/mowedline.el
+++ b/mowedline.el
@@ -60,8 +60,8 @@
   "Perform a mowedline update for the given widget and value
 directly via dbus."
   (dbus-call-method
-   :session "mowedline.server" "/"
-   "mowedline.interface" "update"
+   :session "net.retroj.mowedline" "/net/retroj/mowedline"
+   "net.retroj.mowedline" "update"
    (if (symbolp widget)
        (symbol-name widget)
      widget)

--- a/mowedline.scm
+++ b/mowedline.scm
@@ -16,7 +16,6 @@
 ;; along with mowedline.  If not, see <http://www.gnu.org/licenses/>.
 
 (include "llog")
-(include "mowedline-dbus")
 
 (module mowedline
     *
@@ -47,9 +46,9 @@
      xtypes)
 
 (import llog)
-(import mowedline-dbus)
 
 (include "version")
+(include "mowedline-dbus")
 
 (include "utils")
 

--- a/mowedline.scm
+++ b/mowedline.scm
@@ -48,7 +48,7 @@
 (import llog)
 
 (include "version")
-(include "mowedline-dbus")
+(include "mowedline-dbus-context")
 
 (include "utils")
 
@@ -862,16 +862,15 @@
           (load-startup-script))
         (maybe-make-default-window)
 
-        (let ((dbus-context (mowedline-dbus-context)))
-          (dbus:enable-polling-thread! enable: #f)
-          (dbus:register-method dbus-context "update" update)
-          (dbus:register-method dbus-context "quit" dbus-client-quit)
-          (dbus:register-method dbus-context "log" log-watch)
-          (register-dbus-introspection
-           segments: `(("" ,(dbus-introspect-part "net"))
-                       ("net" ,(dbus-introspect-part "retroj"))
-                       ("retroj" ,(dbus-introspect-part "mowedline"))
-                       ("mowedline" ,dbus-introspect))))
+        (dbus:enable-polling-thread! enable: #f)
+        (dbus:register-method mowedline-dbus-context "update" update)
+        (dbus:register-method mowedline-dbus-context "quit" dbus-client-quit)
+        (dbus:register-method mowedline-dbus-context "log" log-watch)
+        (register-dbus-introspection
+         segments: `(("" ,(dbus-introspect-part "net"))
+                     ("net" ,(dbus-introspect-part "retroj"))
+                     ("retroj" ,(dbus-introspect-part "mowedline"))
+                     ("mowedline" ,dbus-introspect)))
 
         (define (x-eventloop)
           (unless (> (xpending display) 0)


### PR DESCRIPTION
It is convention to use a reversed domain to name the service, dbus path and interface. It is also recommended against to use the path “/” for dbus services because it makes versioning more difficult and makes it hard for signal listeners to determine where the signal originated from.

For introspection it seems necessary to respond to each path segment separately. Testing with D-feet stopped working when the path was introduced, but looking at other programs it seems to be necessary to respond to each segment separately and name the next segment. For example, the “/” points to the “/net” path:

    <node> 
      <node name="net"/> 
    </node>

And then the “/net” path points to the “/net/retroj” path.

    <node> 
      <node name="retroj"/> 
    </node>

Place the variables naming the path, service name and interface in a separate file so both the client and the server can use it without dublicating the information, in case we ever want to change it.  Keep the introspection code in the ‘mowedline’ module because the client doesn’t need it.